### PR TITLE
Add support for Dimmer switches

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -544,6 +544,8 @@ class BasePlugin:
                         if int(nodeType) == 244:   # This is a switch
                             if nodeSwitchtype == '0': # This is an On/Off switch
                                 nValueToSet = 0 if str(valueToSet) == '0' else 1
+                            elif nodeSwitchtype == '7': # This is a Dimmer switch
+                                nValueToSet = 0 if str(valueToSet) == '0' else 1 if str(valueToSet) == '100' else 2
                             else:   # Not a switch, use given value
                                 nValueToSet = int(valueToSet)
                             sValueToSet = str(valueToSet)


### PR DESCRIPTION
Added support for Dimmer switches (Type 244 / SwitchType 7), nValue depends on sValue.

Link to Domoticz doc: https://wiki.domoticz.com/Domoticz_API/JSON_URL%27s#Set_a_dimmable_light/selector_to_a_certain_level

dimmable:
Some lights have 100 dim levels (like zwave and others), other hardware (kaku/lightwaverf) have other ranges like 16/32
Level should be the dim level (not percentage), like 0-16 or 0-100 depending on the hardware used
When the light is off, it will be turned on
Blinds: enter percentage, level will be 0-100
Selector switch: enter the level number (eg 10, 20 or 30) that can be found in the edit section of a switch.
To update in Domoticz only without running it's device actions use /json.htm?type=command&param=udevice&idx=IDX&nvalue=[0,1,2]&svalue=LEVELNR Statuses for Blinds Percentage when using &param=udevice:
      Closed: nValue = 1 and sValue = 100
      partially opened: nValue = 2 and sValue = 1-99
      Open: nValue = 0 and sValue = 0 